### PR TITLE
Fix writeToFile function call

### DIFF
--- a/scripts/process_annotations.js
+++ b/scripts/process_annotations.js
@@ -474,7 +474,7 @@ ${annos}
 `;
 
 	const path = outputPath + `/${metad.citekey}.md`;
-	writeToFile(noteContent, path);
+	writeToFile(path, noteContent);
 
 	// automatically determine if file is an Obsidian Vault
 	const obsidianJson = app.pathTo("home folder") + "/Library/Application Support/obsidian/obsidian.json";


### PR DESCRIPTION
Hello! After the last release, I was having an issue where I could use the workflow and it didn't report any errors, but the literature note wouldn't be created. 

I noticed the last release flipped the `text` and `filepath` arguments of the `writeToFile()` function, but the change hadn't been applied when the function was called inside `writeNote()`, and flipping the arguments fixes the issue.