### PR TITLE
Fix file names with hidden extensions in Highlights

### DIFF
--- a/scripts/get-pdf-path.applescript
+++ b/scripts/get-pdf-path.applescript
@@ -49,6 +49,7 @@ if (frontApp is "Highlights") then
 
 	set AppleScript's text item delimiters to " – "
 	set filename to text item 1 of frontWindow
+	set filename to do shell script ("filename=" & (quoted form of filename) & "; echo \"${filename%.pdf}.pdf\"")
 
 	set current_file to do shell script ("find " & (quoted form of pdfFolder) & " -type f -name " & (quoted form of filename))
 end if


### PR DESCRIPTION
Hello again! This is probably a fairly niche issue, but I wanted to point it out just in case it happens to anyone else. 

Due to the way that the PDF filename is determined from the Highlights app, if the file's extension is hidden (e.g., Highlights is showing just "Article-Name" instead of "Article-Name.pdf"), the `find` function won't be able to match the file and the workflow will error with "Not a .pdf file." 

I added a line to `get-pdf-path` to standardize the file extension by first removing ".pdf" if it's present and then adding ".pdf" back to make sure it's present on all files from Highlights. 