### PR TITLE
Fix underscore annotations for loop

### DIFF
--- a/scripts/process_annotations.js
+++ b/scripts/process_annotations.js
@@ -132,9 +132,10 @@ function underlinesToSidenotes(annotations, citekey) {
 	if (totInstalled) {
 		const underscoreAnnos = [];
 		for (const anno of annotations) {
-			if (!anno.comment?.startsWith("_")) return;
-			anno.comment = anno.comment.slice(1).trim(); // remove "_" prefix
-			underscoreAnnos.push(anno);
+			if (anno.comment?.startsWith("_")) {
+				anno.comment = anno.comment.slice(1).trim(); // remove "_" prefix
+				underscoreAnnos.push(anno);
+			}
 		}
 
 		const underlineAnnos = annotations.filter((a) => a.type === "Underline");


### PR DESCRIPTION
Hello!

After updating to the latest version, I got an error `./scripts/process_annotations.js: execution error: Error: TypeError: undefined is not an object (evaluating 'annotations.map') (-2700)` whenever running the annotation extraction. 

I'm not particularly familiar with JavaScript, but after debugging the changes in the update, I think the issue is in the `return` statement in the processing of annotations beginning with "\_". Changing the `if` statement fixes the error (tested on PDFs with and without "\_" annotations). 